### PR TITLE
Add SQLiteConnection support

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -117,6 +117,46 @@ jobs:
           DB_PORT: ${{ job.services.mysql.ports[3306] }}
           DB_COLLATION: utf8mb4_unicode_ci
 
+  sqlite_test:
+    name: Run PHPUnit on PHP ${{ matrix.php }} and SQLite with ${{ matrix.dependencies }} dependencies
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['7.3', '7.4', '8.0', '8.1', '8.2']
+        dependencies: ['lowest', 'highest']
+        exclude:
+          - php: '8.2'
+            dependencies: 'lowest'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: pdo, pdo_sqlite
+          tools: composer:v2
+          coverage: none
+
+      - name: Install Composer dependencies with the highest version
+        if: matrix.dependencies == 'highest'
+        run: composer update --no-interaction --no-progress
+
+      - name: Install Composer dependencies with the lowest stable version
+        if: matrix.dependencies == 'lowest'
+        run: composer update --no-interaction --no-progress --prefer-lowest --prefer-stable
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit
+        env:
+          DB_CONNECTION: sqlite
+          DB_DATABASE: ':memory:'
+
   coverage:
     name: Analyze code coverage
 

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,10 @@ test.mysql:
 test.pgsql:
 	docker compose -f docker-compose.yml -f docker-compose.pgsql.yml run --rm ${PHPUNIT_RUN}
 
+# Run PHPUnit with SQLite service
+test.sqlite:
+	docker compose -f docker-compose.yml -f docker-compose.sqlite.yml run --rm ${PHPUNIT_RUN}
+
 # Run PHPUnit with a coverage analysis using an HTML output
 phpunit.coverage.html:
 	docker compose ${COMPOSE} run --rm ${PHPUNIT_RUN} --coverage-html tests/.report

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ composer require nevadskiy/laravel-tree
 
 ## ✨ How it works
 
-When working with hierarchical data structures in your application, storing the structure using a self-referencing `parent_id` column is a common approach.  
+When working with hierarchical data structures in your application, storing the structure using a self-referencing `parent_id` column is a common approach.
 While it works well for many use cases, it can become challenging when you need to make complex queries, such as finding all descendants of a given node.
 One of the simples and effective solutions is the [materialized path](#materialized-path) pattern.
 
 ### Materialized path
 
-The "materialized pattern" involves storing the full path of each node in the hierarchy in a separate `path` column as a string. 
+The "materialized pattern" involves storing the full path of each node in the hierarchy in a separate `path` column as a string.
 The ancestors of each node are represented by a series of IDs separated by a delimiter.
 
 For example, the categories database table might look like this:
@@ -128,7 +128,7 @@ Sometimes the Ltree extension may be disabled in PostgreSQL. To enable it, you c
 php artisan vendor:publish --tag=pgsql-ltree-migration
 ```
 
-#### Using MySQL database
+#### Using MySQL or SQLite database
 
 To add a string `path` column with and an index, use the following code:
 
@@ -172,7 +172,7 @@ The `AsTree` trait provides the following relations:
 
 The `parent` and `children` relations use default Laravel `BelongsTo` and `HasMany` relation classes.
 
-The `ancestors` and `descendants` can be used only in the "read" mode, which means methods like `make` or `create` are not available. 
+The `ancestors` and `descendants` can be used only in the "read" mode, which means methods like `make` or `create` are not available.
 So to save related nodes you need to use the `parent` or `children` relation.
 
 #### Parent
@@ -197,7 +197,7 @@ foreach ($category->children as $child) {
 
 #### Ancestors
 
-The `ancestors` relation is a custom relation that works only in "read" mode. 
+The `ancestors` relation is a custom relation that works only in "read" mode.
 It allows getting all ancestors of the node (without the current node).
 
 Using the attribute:
@@ -244,13 +244,13 @@ $ancestors = $category->descendants()->get();
 Getting root nodes:
 
 ```php
-$roots = Category::query()->root()->get(); 
+$roots = Category::query()->root()->get();
 ```
 
 Getting nodes by the depth level:
 
 ```php
-$categories = Category::query()->whereDepth(3)->get(); 
+$categories = Category::query()->whereDepth(3)->get();
 ```
 
 Getting ancestors of the node (including the current node):

--- a/docker-compose.sqlite.yml
+++ b/docker-compose.sqlite.yml
@@ -1,0 +1,7 @@
+version: '3.9'
+
+services:
+  phpunit:
+    environment:
+      DB_CONNECTION: sqlite
+      DB_DATABASE: ':memory:'

--- a/src/Database/BuilderMixin.php
+++ b/src/Database/BuilderMixin.php
@@ -335,11 +335,15 @@ class BuilderMixin
     }
 
     /**
-     * Compile the MySQL "depth" function for the given column.
+     * Compile the SQLite "depth" function for the given column.
      */
     protected function compileSqliteDepth(): callable
     {
-        return $this->compileMysqlDepth();
+        return function (string $column, string $separator = Path::SEPARATOR) {
+            return new Expression(vsprintf("(length(%s) - length(replace(%s, '%s', ''))) + 1", [
+                $column, $column, $separator
+            ]));
+        };
     }
 
     /**

--- a/tests/Database/migrations/sqlite/2023_04_16_100000_create_substring_index_function.php
+++ b/tests/Database/migrations/sqlite/2023_04_16_100000_create_substring_index_function.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (DB::getDriverName() === 'sqlite') {
+            DB::connection()->getPdo()->sqliteCreateFunction('substring_index', function ($string, $delimiter, $count) {
+                if ($count > 0) {
+                    return implode($delimiter, array_slice(explode($delimiter, $string), 0, $count));
+                }
+                elseif ($count < 0) {
+                    return implode($delimiter, array_slice(explode($delimiter, $string), $count));
+                }
+                return '';
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/tests/Database/migrations/sqlite/2023_04_16_100000_create_substring_index_function.php
+++ b/tests/Database/migrations/sqlite/2023_04_16_100000_create_substring_index_function.php
@@ -13,8 +13,7 @@ return new class () extends Migration {
             DB::connection()->getPdo()->sqliteCreateFunction('substring_index', function ($string, $delimiter, $count) {
                 if ($count > 0) {
                     return implode($delimiter, array_slice(explode($delimiter, $string), 0, $count));
-                }
-                elseif ($count < 0) {
+                } elseif ($count < 0) {
                     return implode($delimiter, array_slice(explode($delimiter, $string), $count));
                 }
                 return '';

--- a/tests/Database/migrations/sqlite/2023_04_16_180000_create_categories_table.php
+++ b/tests/Database/migrations/sqlite/2023_04_16_180000_create_categories_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('path')->nullable()->index();
+            $table->timestamps();
+        });
+
+        Schema::table('categories', function (Blueprint $table) {
+            $table->foreignId('parent_id')
+                ->nullable()
+                ->index()
+                ->constrained('categories')
+                ->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/tests/Database/migrations/sqlite/2023_04_16_180000_create_products_table.php
+++ b/tests/Database/migrations/sqlite/2023_04_16_180000_create_products_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('products', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->foreignId('category_id')->index()->references('id')->on('categories');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('products');
+    }
+};

--- a/tests/Database/migrations/sqlite/2023_04_16_180000_create_uuid_categories_table.php
+++ b/tests/Database/migrations/sqlite/2023_04_16_180000_create_uuid_categories_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('uuid_categories', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('name');
+            $table->string('path')->index();
+            $table->timestamps();
+        });
+
+        Schema::table('uuid_categories', function (Blueprint $table) {
+            $table->foreignUuid('parent_id')
+                ->nullable()
+                ->index()
+                ->constrained('uuid_categories')
+                ->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('uuid_categories');
+    }
+};


### PR DESCRIPTION
This PR adds support for the SQLiteConnection driver.

It should not bring breaking changes as it only add support for a previously unsupported driver.

One can run tests by setting `DB_CONNECTION=sqlite` in the `.env` file. No additional test were added as this PR intend to support the same features as the one already available for the PGSQL and MySQL drivers. 